### PR TITLE
Add `SparseMap` as underlying data strucutre

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ thinset = "0.1"
 
 <!-- cargo-rdme start -->
 
-An implementation of a set using a pair of sparse and dense arrays as backing stores.
+An implementation of a set and a map using a pair of sparse and dense arrays as backing stores.
 
 This type of set is useful when you need to efficiently track set membership for integers
 from a large universe, but the values are relatively spread apart.
@@ -54,6 +54,9 @@ In addition:
 proportional to the cardinality of the set (how many elements you have) instead of proportional to the maximum size of the set.
 
 The main downside is that the set requires more memory than other set implementations.
+
+The map behaves identically to the set with the exception that it tracks data alongside
+the values that are stored in the set. Under the hood, `SparseSet` is a `SparseMap` of keys to `()`.
 
 The implementation is based on the paper "An efficient representation for sparse sets" (1993)
 by Briggs and Torczon.
@@ -77,6 +80,22 @@ if !s.contains(7) {
 // Print 0, 1, 3 in some order
 for x in s.iter() {
     println!("{}", x);
+}
+```
+
+```rust
+use thinset::{Pair, SparseMap};
+
+let mut m: SparseMap<u32, u32> = SparseMap::new();
+
+m.insert(13, 2);
+m.insert(8, 16);
+
+assert_eq!(m.get(13), Some(2));
+assert_eq!(m.get(6), None);
+
+for Pair {key, value} in m.iter() {
+    println!("{key}:{value}");
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ by Briggs and Torczon.
 ```rust
 use thinset::SparseSet;
 
-// Specify a maximum value for the set
-let mut s: SparseSet<usize> = SparseSet::new(100);
+let mut s: SparseSet<usize> = SparseSet::new();
 s.insert(0);
 s.insert(3);
 s.insert(7);

--- a/examples/count_chars.rs
+++ b/examples/count_chars.rs
@@ -1,0 +1,22 @@
+use thinset::{SparseMap, Pair};
+use std::env;
+
+fn main() {
+    let mut args = env::args();
+    args.next();
+    let s = args.next().expect("Pass a string to count the number of characters of");
+
+    let mut map = SparseMap::new();
+    for ch in s.chars() {
+        map.update(ch as u8, 1, |n| n + 1);
+    }
+
+    println!("The following characters occur in the string '{}':", s);
+    for Pair { key, value } in map.iter() {
+        if *value == 1 {
+            println!(" '{}' once", *key as char);
+        } else {
+            println!(" '{}' {} times", *key as char, *value);
+        }
+    }
+}

--- a/examples/count_chars.rs
+++ b/examples/count_chars.rs
@@ -1,10 +1,12 @@
-use thinset::{SparseMap, Pair};
 use std::env;
+use thinset::{Pair, SparseMap};
 
 fn main() {
     let mut args = env::args();
     args.next();
-    let s = args.next().expect("Pass a string to count the number of characters of");
+    let s = args
+        .next()
+        .expect("Pass a string to count the number of characters of");
 
     let mut map = SparseMap::new();
     for ch in s.chars() {

--- a/examples/count_chars.rs
+++ b/examples/count_chars.rs
@@ -10,7 +10,7 @@ fn main() {
 
     let mut map = SparseMap::new();
     for ch in s.chars() {
-        map.update(ch as u8, 1, |n| n + 1);
+        map.update(ch as u8, |n| n + 1, 1);
     }
 
     println!("The following characters occur in the string '{}':", s);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@ impl<K: PrimInt + Unsigned, V: Copy> SparseMap<K, V> {
 
         let r = self.sparse[ukey];
 
-        // Overwrite the value if they key is already present.
+        // Overwrite the value if the key is already present.
         if r < self.dense.len() && self.dense[r].key == key {
             self.dense[r].value = value;
             return false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,6 +503,13 @@ mod tests {
         assert!(!map.contains(14));
         assert_eq!(map.get(0), Some(1));
         assert_eq!(map.get(41), Some(2));
+        assert_eq!(map.get(14), None);
+
+        map.update(41, 0, |n| n * n);
+        assert_eq!(map.get(41), Some(4));
+        // TODO: Would it be better if f were always applied?
+        map.update(14, 10, |n| n);
+        assert_eq!(map.get(14), Some(10));
 
         map.clear();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,6 +480,8 @@ macro_rules! set {
 mod tests {
     use super::*;
 
+    use rand::Rng;
+
     #[test]
     fn sparse_map_example() {
         let map: SparseMap<usize, usize> = SparseMap::with_capacity(50);
@@ -570,8 +572,11 @@ mod tests {
 
     #[test]
     fn sparse_map_insert_random_values() {
-        let k = gen_random_vec();
-        let v = gen_random_vec();
+        let mut rng = rand::thread_rng();
+        let size = rng.gen_range(0x100..0x1000);
+
+        let k = gen_random_vec(size);
+        let v = gen_random_vec(size);
         let mut m: SparseMap<u32, u32> = SparseMap::new();
 
         // Check that inserting random values works.
@@ -738,7 +743,8 @@ mod tests {
 
     #[test]
     fn sparse_set_insert_random_values() {
-        let r = gen_random_vec();
+        let mut rng = rand::thread_rng();
+        let r = gen_random_vec(rng.gen_range(0x100..0x1000));
         let mut s: SparseSet<u32> = SparseSet::new();
 
         // Check that inserting random values works.
@@ -760,11 +766,8 @@ mod tests {
         assert!(s.is_empty());
     }
 
-    fn gen_random_vec() -> Vec<u32> {
-        use rand::Rng;
+    fn gen_random_vec(size: usize) -> Vec<u32> {
         let mut rng = rand::thread_rng();
-
-        let size = rng.gen_range(0x100..0x1000);
         let mut vec = Vec::with_capacity(size);
 
         for _ in 0..size {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ impl<K: PrimInt + Unsigned, V: Copy> SparseMap<K, V> {
     /// # Panics
     ///
     /// If `key` cannot be cast to `usize`.
-    pub fn update<F>(&mut self, key: K, default: V, f: F) -> bool
+    pub fn update<F>(&mut self, key: K, f: F, default: V) -> bool
     where
         F: Fn(V) -> V,
     {
@@ -524,10 +524,9 @@ mod tests {
         assert_eq!(map.get(41), Some(2));
         assert_eq!(map.get(14), None);
 
-        map.update(41, 0, |n| n * n);
+        map.update(41, |n| n * n, 0);
         assert_eq!(map.get(41), Some(4));
-        // TODO: Would it be better if f were always applied?
-        map.update(14, 10, |n| n);
+        map.update(14, |n| n, 10);
         assert_eq!(map.get(14), Some(10));
 
         map.clear();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,8 @@ use num_traits::Unsigned;
 /// A pair stored in the map. Mostly used for readability advantages over (,).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Pair<K: PrimInt + Unsigned, V: Copy> {
-    key: K,
-    value: V,
+    pub key: K,
+    pub value: V,
 }
 
 impl<K: PrimInt + Unsigned, V: Copy> Pair<K, V> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -625,6 +625,13 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
+    fn sparse_map_key_must_fit_usize() {
+        let map: SparseMap<u128, i32> = SparseMap::new();
+        map.contains(usize::MAX as u128 + 1);
+    }
+
+    #[test]
     fn sparse_set_example() {
         let set: SparseSet<usize> = SparseSet::with_capacity(50);
         assert!(set.is_empty());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,28 +408,10 @@ mod tests {
 
     #[test]
     fn sparse_set_contains_value_out_of_bounds() {
-        let mut set: SparseSet<usize> = SparseSet::with_capacity(0);
+        let set: SparseSet<usize> = SparseSet::with_capacity(0);
         assert_eq!(set.len(), 0);
         assert!(!set.contains(0));
         assert!(!set.contains(100));
-        set.insert(4);
-        assert!(set.contains(4));
-    }
-
-    #[test]
-    fn sparse_set_fit_bounds() {
-        let mut s: SparseSet<u8> = SparseSet::with_capacity(u8::MAX as usize + 10);
-        for i in 0..u8::MAX {
-            s.insert(i);
-        }
-        for i in 0..u8::MAX {
-            assert!(s.contains(i));
-        }
-        assert_eq!(s.len(), u8::MAX as usize);
-        for i in 0..u8::MAX {
-            assert!(s.remove(i));
-        }
-        assert_eq!(s.len(), 0);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ impl<T: PrimInt + Unsigned> SparseSet<T> {
 
         true
     }
-
+ 
     /// Returns true if the set contains no elements.
     pub fn is_empty(&self) -> bool {
         self.dense.is_empty()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ impl<T: PrimInt + Unsigned> SparseSet<T> {
 
         true
     }
- 
+
     /// Returns true if the set contains no elements.
     pub fn is_empty(&self) -> bool {
         self.dense.is_empty()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -631,6 +631,24 @@ mod tests {
     }
 
     #[test]
+    fn sparse_set_unit_tuple_trick_works() {
+        use std::mem::size_of;
+
+        // `SparseSet` is a `SparseMap` of `Pair<K, ()>`s. On every insertion into
+        // the map, such a pair is appended to the end of `dense`. This test asserts
+        // that using the unit tuple trick to implement a set on top of a map uses
+        // the same amount of memory as a direct implementation of the set would. The
+        // same trick is employed by `std::collections::HashSet`.
+
+        assert_eq!(size_of::<usize>(), size_of::<Pair<usize, ()>>());
+        assert_eq!(size_of::<u128>(), size_of::<Pair<u128, ()>>());
+        assert_eq!(size_of::<u64>(), size_of::<Pair<u64, ()>>());
+        assert_eq!(size_of::<u32>(), size_of::<Pair<u32, ()>>());
+        assert_eq!(size_of::<u16>(), size_of::<Pair<u16, ()>>());
+        assert_eq!(size_of::<u8>(), size_of::<Pair<u8, ()>>());
+    }
+
+    #[test]
     fn sparse_set_example() {
         let set: SparseSet<usize> = SparseSet::with_capacity(50);
         assert!(set.is_empty());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! An implementation of a set using a pair of sparse and dense arrays as backing stores.
+//! An implementation of a set and a map using a pair of sparse and dense arrays as backing stores.
 //!
 //! This type of set is useful when you need to efficiently track set membership for integers
 //! from a large universe, but the values are relatively spread apart.
@@ -11,6 +11,9 @@
 //! proportional to the cardinality of the set (how many elements you have) instead of proportional to the maximum size of the set.
 //!
 //! The main downside is that the set requires more memory than other set implementations.
+//!
+//! The map behaves identically to the set with the exception that it tracks data alongside
+//! the values that are stored in the set. Under the hood, `SparseSet` is a `SparseMap` of keys to `()`.
 //!
 //! The implementation is based on the paper "An efficient representation for sparse sets" (1993)
 //! by Briggs and Torczon.
@@ -34,6 +37,22 @@
 //! // Print 0, 1, 3 in some order
 //! for x in s.iter() {
 //!     println!("{}", x);
+//! }
+//! ```
+//!
+//! ```
+//! use thinset::{Pair, SparseMap};
+//!
+//! let mut m: SparseMap<u32, u32> = SparseMap::new();
+//!
+//! m.insert(13, 2);
+//! m.insert(8, 16);
+//!
+//! assert_eq!(m.get(13), Some(2));
+//! assert_eq!(m.get(6), None);
+//!
+//! for Pair {key, value} in m.iter() {
+//!     println!("{key}:{value}");
 //! }
 //! ```
 


### PR DESCRIPTION
In addition to the key that points back into `sparse`, `SparseMap` also stores some data associated with the key in `dense`. The data can be anything that's `Copy`. This way, all numeric types supported as keys should work as values. In addition, types like the unit tuple can be used as values. `SparseSet` wraps the underlying map and uses `()` for every  value in the map.

The `Pair` typed used to store key-value pairs is mostly used for improved readability of code. It could be used to implement a similar interface to the `Entry` type in `std::collections::HashMap`. The `update` and `get` functions are very basic and need further improvement.