### PR TITLE
Implement `Index` and `IndexMut` for `SparseMap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ let mut m: SparseMap<u32, u32> = SparseMap::new();
 m.insert(13, 2);
 m.insert(8, 16);
 
-assert_eq!(m.get(13), Some(2));
+assert_eq!(m.get(13), Some(&2));
 assert_eq!(m.get(6), None);
 
 for Pair {key, value} in m.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //! m.insert(13, 2);
 //! m.insert(8, 16);
 //!
-//! assert_eq!(m.get(13), Some(2));
+//! assert_eq!(m.get(13), Some(&2));
 //! assert_eq!(m.get(6), None);
 //!
 //! for Pair {key, value} in m.iter() {
@@ -185,7 +185,7 @@ impl<K: PrimInt + Unsigned, V: Copy> SparseMap<K, V> {
     /// # Panics
     ///
     /// If `key` cannot be cast to `usize`.
-    pub fn get(&self, key: K) -> Option<V> {
+    pub fn get(&self, key: K) -> Option<&V> {
         let ukey = key.to_usize().unwrap();
         if ukey >= self.cap {
             return None;
@@ -193,7 +193,27 @@ impl<K: PrimInt + Unsigned, V: Copy> SparseMap<K, V> {
 
         let r = self.sparse[ukey];
         if r < self.dense.len() && self.dense[r].key == key {
-            return Some(self.dense[r].value);
+            return Some(&self.dense[r].value);
+        }
+
+        None
+    }
+
+    /// Get mutable access to the value behind the given `key`.
+    /// Returns `None` if the key doesn't exist.
+    ///
+    /// # Panics
+    ///
+    /// If `key` cannot be cast to `usize`.
+    pub fn get_mut(&mut self, key: K) -> Option<&mut V> {
+        let ukey = key.to_usize().unwrap();
+        if ukey >= self.cap {
+            return None;
+        }
+
+        let r = self.sparse[ukey];
+        if r < self.dense.len() && self.dense[r].key == key {
+            return Some(&mut self.dense[r].value);
         }
 
         None
@@ -336,6 +356,20 @@ impl<K: PrimInt + Unsigned, V: Copy> Iterator for SparseMapIntoIter<K, V> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+}
+
+impl<K: Unsigned + PrimInt, V: Copy> std::ops::Index<K> for SparseMap<K, V> {
+    type Output = V;
+
+    fn index(&self, key: K) -> &Self::Output {
+        self.get(key).unwrap()
+    }
+}
+
+impl<K: Unsigned + PrimInt, V: Copy> std::ops::IndexMut<K> for SparseMap<K, V> {
+    fn index_mut(&mut self, key: K) -> &mut Self::Output {
+        self.get_mut(key).unwrap()
     }
 }
 
@@ -520,14 +554,14 @@ mod tests {
         assert!(map.contains(0));
         assert!(map.contains(41));
         assert!(!map.contains(14));
-        assert_eq!(map.get(0), Some(1));
-        assert_eq!(map.get(41), Some(2));
+        assert_eq!(map.get(0), Some(&1));
+        assert_eq!(map.get(41), Some(&2));
         assert_eq!(map.get(14), None);
 
         map.update(41, |n| n * n, 0);
-        assert_eq!(map.get(41), Some(4));
+        assert_eq!(map.get(41), Some(&4));
         map.update(14, |n| n, 10);
-        assert_eq!(map.get(14), Some(10));
+        assert_eq!(map.get(14), Some(&10));
 
         map.clear();
 
@@ -628,6 +662,45 @@ mod tests {
     fn sparse_map_key_must_fit_usize() {
         let map: SparseMap<u128, i32> = SparseMap::new();
         map.contains(usize::MAX as u128 + 1);
+    }
+
+    #[test]
+    fn sparse_map_can_be_indexed() {
+        let mut map: SparseMap<u32, i32> = SparseMap::new();
+        map.insert(10, 100);
+        map.insert(5, 50);
+        assert_eq!(map[10], 100);
+        assert_eq!(map[5], 50);
+    }
+
+    #[test]
+    #[should_panic]
+    fn sprase_map_index_out_of_range() {
+        let mut map: SparseMap<u32, i32> = SparseMap::new();
+        map.insert(4, 5);
+        let _ = map[5];
+    }
+
+    #[test]
+    fn sparse_map_can_be_indexed_mutably() {
+        let mut map: SparseMap<u32, i32> = SparseMap::new();
+        map.insert(6, 10);
+        assert_eq!(map.get(6), Some(&10));
+        map[6] = 5;
+        assert_eq!(map.get(6), Some(&5));
+        let x = &mut map[6];
+        *x = 7;
+        *x += 1;
+        assert_eq!(map.get(6), Some(&8));
+    }
+
+    #[test]
+    #[should_panic]
+    fn sparse_map_mutable_index_out_of_range() {
+        let mut map: SparseMap<u32, i32> = SparseMap::new();
+        map.insert(51, 0);
+        let x: &mut i32 = &mut map[53];
+        *x = 60;
     }
 
     #[test]


### PR DESCRIPTION
`Index` and `IndexMut` allows using the `map[x]`
syntax to retrieve and mutate values in the map.
Both traits are implemented as wrappers around
`get` and `get_mut`, respectively.

The `SparseMap::get` now returns an `Option<&V>`
to accommodate the type needs of `Index`.

`get_mut` was added to retrieve mutable references
for `IndexMut`. Handing out mutable access to the
values inside the map is safe because the algorithm
for maintaining valid map entries doesn't depend
on the value stored in any of the pairs in `dense`. In
addition, Rust guarantees that the underlying
structure of the map is not changed while a mutable
reference is alive, so the internal swapping is not a
concern either :)

Closes #9