### PR TITLE
Fix safety hole, use zeroed memory for set allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,18 +77,19 @@ The table below compares the asymptotic complexities of several set operations f
 The following benchmarks were run on a 2020 MacBook Pro with a 2 GHz Intel Core i5 processor.
 
 The benchmark compares `SparseSet` to the standard library's `HashSet` and the `bit-set` crate's `BitSet`.
+It assumes the set is being reused by the program and new sets do not need to be created often.
 
-When inserting 1000 random elements into the set from a universe of [0, 2^16) and then iterating over the set,
-the sparse set is **4.1x** faster than the `HashSet` and **1.7x** faster than the `BitSet`:
+When inserting 1000 random elements into the set from a universe of [0, 2^16) iterating over the set, and clearing it,
+the sparse set is **1.7** faster than the `HashSet` and **1.6x** faster than the `BitSet`:
 
-- `SparseSet`: 160,329 ns/iter (+/- 55,664)
-- `BitSet`: 278,428 ns/iter (+/- 42,477)
-- `HashSet`: 662,964 ns/iter (+/- 56,851)
+- `SparseSet`: 9,574 ns/iter (+/- 87)
+- `BitSet`: 15,318 ns/iter (+/- 171)
+- `HashSet`: 16,613 ns/iter (+/- 311)
 
 Benchmarks are available in examples/bench.rs and can be run with the following command:
 
 ```bash
-cargo run --example bench
+cargo run --example bench --release
 ```
 
 #### Examples

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Compared to the standard library's `HashSet`, clearing a set is O(1) instead of 
 Compared to a bitmap-based set, iteration over the set is
 proportional to the cardinality of the set (how many elements you have) instead of proportional to the maximum size of the set.
 
-The main downside is that the set uses more memory than other set implementations.
+The main downside is that the set uses more memory than other set implementations. Its ideal usage is in
+scenarios where the same set(s) can be reused many times (e.g. by using the `clear` operation).
 
 The map behaves identically to the set with the exception that it tracks data alongside
 the values that are stored in the set. Under the hood, `SparseSet` is a `SparseMap` of keys to `()`.

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -9,40 +9,43 @@ const BITS: usize = 2 << 16;
 
 fn bench_sparse_set(b: &mut Bencher) {
     let mut r = thread_rng();
+    let mut set = SparseSet::with_capacity(BITS);
     b.iter(|| {
-        let mut set = SparseSet::with_capacity(BITS);
         for _ in 0..1000 {
             set.insert((r.next_u32() as usize) % BITS);
         }
         for x in set.iter() {
             black_box(x);
         }
+        set.clear();
     });
 }
 
 fn bench_hash_set(b: &mut Bencher) {
     let mut r = thread_rng();
+    let mut set = std::collections::HashSet::new();
     b.iter(|| {
-        let mut set = std::collections::HashSet::new();
         for _ in 0..1000 {
             set.insert((r.next_u32() as usize) % BITS);
         }
         for x in set.iter() {
             black_box(x);
         }
+        set.clear();
     });
 }
 
 fn bench_bit_set(b: &mut Bencher) {
     let mut r = thread_rng();
+    let mut set = bit_set::BitSet::new();
     b.iter(|| {
-        let mut set = bit_set::BitSet::new();
         for _ in 0..1000 {
             set.insert((r.next_u32() as usize) % BITS);
         }
         for x in set.iter() {
             black_box(x);
         }
+        set.clear();
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,8 @@
 //! Compared to a bitmap-based set, iteration over the set is
 //! proportional to the cardinality of the set (how many elements you have) instead of proportional to the maximum size of the set.
 //!
-//! The main downside is that the set uses more memory than other set implementations.
+//! The main downside is that the set uses more memory than other set implementations. Its ideal usage is in
+//! scenarios where the same set(s) can be reused many times (e.g. by using the `clear` operation).
 //!
 //! The map behaves identically to the set with the exception that it tracks data alongside
 //! the values that are stored in the set. Under the hood, `SparseSet` is a `SparseMap` of keys to `()`.


### PR DESCRIPTION
As noted in a code comment, the main "trick" to the algorithm in this crate (also described in [this blog](https://research.swtch.com/sparse)) isn't safe in Rust because it requires reading uninitialized memory from one vector and interpreting the bits as indices into the other vector. Most documentation and discussion posts I was able to find online seem to point to this being something that is undefined behavior, meaning the Rust compiler (or LLVM bytecode compiler) might perform invalid optimizations like removing statements etc. because of it.

Since safety is a priority for this library, out of caution, I've updated the code to use zeroed-out vectors instead. This mostly hurts initialization performance, but I think it's still possible to use the data structure in some scenarios. I've updated and reran benchmarks (which previously weren't ran on release mode).

Closes #3